### PR TITLE
Update order.func

### DIFF
--- a/contracts/order.func
+++ b/contracts/order.func
@@ -149,7 +149,7 @@ slice get_text_comment(slice in_msg_body) impure inline {
             0,
             begin_cell()
             .store_op_and_query_id(op::approve_rejected, query_id)
-            .store_uint(exit_code, 32),
+            .store_uint(exit_code.cast_to_int(), 32),
             NON_BOUNCEABLE,
             SEND_MODE_CARRY_ALL_REMAINING_MESSAGE_VALUE | SEND_MODE_BOUNCE_ON_ACTION_FAIL
         );


### PR DESCRIPTION
Note that exception parameter can be of any type (possibly different in case of different exceptions) and thus funC can not predict it on compile time. That means that developer need to "help" compiler by casting exception parameter to some type (see Example 2 below):
https://docs.ton.org/develop/func/statements#try-catch-statements